### PR TITLE
Fix not showing curly error when using C++11

### DIFF
--- a/after/syntax/c.vim
+++ b/after/syntax/c.vim
@@ -107,7 +107,7 @@ endif
 " also accept <% for {, %> for }, <: for [ and :> for ] (C99)
 " But avoid matching <::.
 syn cluster	cParenGroup	contains=cParenError,cIncluded,cSpecial,cCommentSkip,cCommentString,cComment2String,@cCommentGroup,cCommentStartError,cUserCont,cUserLabel,cBitField,cOctalZero,@cCppOutInGroup,cFormat,cNumber,cFloat,cOctal,cOctalError,cNumbersCom
-if exists("c_no_curly_error") || exists("cpp_no_cpp11")
+if exists("c_no_curly_error") || (&filetype == "cpp" && !exists("cpp_no_cpp11"))
   syn region	cParen		transparent start='(' end=')' end='}'me=s-1 contains=ALLBUT,cBlock,@cParenGroup,cCppParen,cCppString,@Spell
   " cCppParen: same as cParen but ends at end-of-line; used in cDefine
   syn region	cCppParen	transparent start='(' skip='\\$' excludenl end=')' end='$' contained contains=ALLBUT,@cParenGroup,cParen,cString,@Spell


### PR DESCRIPTION
This should fix the issue about disabling curly errors in C++11.
