### PR TITLE
Fix support of raw string literals

### DIFF
--- a/syntax/cpp.vim
+++ b/syntax/cpp.vim
@@ -39,9 +39,9 @@ if !exists("cpp_no_cpp11")
   syn keyword cppExceptions	noexcept
   syn keyword cppStorageClass	constexpr decltype
   syn keyword cppConstant	nullptr
-  " A raw-string looks like R"d(...)d" where d is a (possibly empty) sequence of
-  " A-Z a-z 0-9 _ { } [ ] # < > % : ; . ? * + - / ^ & | ~ ! = , " '
-  syn region cppRawString  matchgroup=cppRawDelim start=+R"\z([[:alnum:]_{}[\]#<>%:;.?*+\-/\^&|~!=,"']*\)(+ end=+)\z1"+ contains=@Spell
+  " A C++11 raw-string literal. It tries to follow 2.14.5 and 2.14.5.2 of the
+  " standard.
+  syn region cppRawString matchgroup=cppRawDelim start=+\%(u8\=\|[LU]\)\=R"\z(\%([ ()\\\d9-\d12]\@![\d0-\d127]\)\{,16}\)(+ end=+)\z1"+ contains=@Spell
 endif
 
 " The minimum and maximum operators in GNU C++


### PR DESCRIPTION
This fix tries to better follow 2.14.5 and 2.14.5.2 of the standard.

``` text
2.14.5 String literals -- [lex.string]

string-literal:
    encoding-prefix(optional) " s-char-sequence(optional) "
    encoding-prefix(optional) R raw-string
encoding-prefix:
    u8
    u
    U
    L
s-char-sequence:
    s-char
    s-char-sequence s-char
s-char:
    any member of the source character set except
        the double-quote ", backslash \, or new-line character
    escape-sequence
    universal-character-name
raw-string:
    " d-char-sequence(optional) ( r-char-sequence(optional) ) d-char-sequence(optional) "
r-char-sequence:
    r-char
    r-char-sequence r-char
r-char:
    any member of the source character set, except
        a right parenthesis ) followed by the initial d-char-sequence
        (which may be empty) followed by a double quote ".
d-char-sequence:
    d-char
    d-char-sequence d-char
d-char:
    any member of the basic source character set except:
        space, the left parenthesis (, the right parenthesis ), the backslash \,
        and the control characters representing horizontal tab,
        vertical tab, form feed, and newline.

2.14.5.2
    A string literal that has an R in the prefix is a raw string literal. The
        d-char-sequence serves as a delimiter.  The terminating d-char-sequence
        of a raw-string is the same sequence of characters as the initial
        d-char-sequence. A d-char-sequence shall consist of at most 16
        characters.
```

It adds support for unicode raw string literals.
