### PR TITLE
Fix C++11 raw string delimiter

### DIFF
--- a/syntax/cpp.vim
+++ b/syntax/cpp.vim
@@ -39,9 +39,9 @@ if !exists("cpp_no_cpp11")
   syn keyword cppExceptions	noexcept
   syn keyword cppStorageClass	constexpr decltype
   syn keyword cppConstant	nullptr
-  " A C++11 raw-string literal. It tries to follow 2.14.5 and 2.14.5.2 of the
-  " standard.
-  syn region cppRawString matchgroup=cppRawDelim start=+\%(u8\=\|[LU]\)\=R"\z(\%([ ()\\\d9-\d12]\@![\d0-\d127]\)\{,16}\)(+ end=+)\z1"+ contains=@Spell
+  syn region cppRawString matchgroup=cppRawDelimiter                          
+    \ start=+\%(u8\|[uLU]\)\=R"\z([[:alnum:]_{}[\]#<>%:;.?*\+\-/\^&|~!=,"']\{,16}\)(+
+    \ end=+)\z1"+ contains=@Spell
 endif
 
 " The minimum and maximum operators in GNU C++
@@ -65,7 +65,7 @@ if version >= 508 || !exists("did_cpp_syntax_inits")
   HiLink cppStructure		Structure
   HiLink cppBoolean		Boolean
   HiLink cppConstant		Constant
-  HiLink cppRawDelim		cFormat
+  HiLink cppRawDelimiter	Delimiter
   HiLink cppRawString		String
   delcommand HiLink
 endif


### PR DESCRIPTION
Fix C++11 raw string syntax group to exactly follow the standard.
Previous version had problems in delimiter definition. I've tested that raw strings with delimiter would not get correctly highlighted in Vim 7.4.283, and would segfault Vim in 7.4.205. Also, too wide character set was allowed for delimiter (non-source characters, like `@$, and whitespaces should be disallowed).
