### PR TITLE
Fix highlight on unnamed class, struct and enum

### DIFF
--- a/syntax/c.vim
+++ b/syntax/c.vim
@@ -379,8 +379,13 @@ endif
 syn cluster	cLabelGroup	contains=cUserLabel
 syn match	cUserCont	display "^\s*\I\i*\s*:$" contains=@cLabelGroup
 syn match	cUserCont	display ";\s*\I\i*\s*:$" contains=@cLabelGroup
-syn match	cUserCont	display "^\s*\I\i*\s*:[^:]"me=e-1 contains=@cLabelGroup
-syn match	cUserCont	display ";\s*\I\i*\s*:[^:]"me=e-1 contains=@cLabelGroup
+if s:ft ==# 'cpp'
+  syn match	cUserCont	display "^\s*\%(class\|struct\|enum\)\@!\I\i*\s*:[^:]"me=e-1 contains=@cLabelGroup
+  syn match	cUserCont	display ";\s*\%(class\|struct\|enum\)\@!\I\i*\s*:[^:]"me=e-1 contains=@cLabelGroup
+else
+  syn match	cUserCont	display "^\s*\I\i*\s*:[^:]"me=e-1 contains=@cLabelGroup
+  syn match	cUserCont	display ";\s*\I\i*\s*:[^:]"me=e-1 contains=@cLabelGroup
+endif
 
 syn match	cUserLabel	display "\I\i*" contained
 


### PR DESCRIPTION
C++ では，特定のクラスから継承して匿名クラスを定義することができます．また，`enum` に underlying type を指定することができます．
これらの構文がラベルの構文に似ており，シンタックスハイライトはラベル部分のみのマッチで行われてしまうので誤ってラベルとしてハイライトされてしまっていました．

``` cpp
struct base{};

int main()
{
    //
    // Below 'enum', 'struct' and 'class' are highlighted as label
    //

    // Specify int as enum's underlying
    enum : int {} aaa;

    // unnamed derived struct
    struct : base {} bbb;

    // unnamed derived class
    class : base {} ccc;

    return 0;
}
```

解決策として，ラベルが `struct`, `class`, `enum` でないかをチェックするようにしました．
