### PR TITLE
Added C++14 binary literal highlight

### DIFF
--- a/syntax/cpp.vim
+++ b/syntax/cpp.vim
@@ -42,6 +42,11 @@ if !exists("cpp_no_cpp11")
   syn region cppRawString       matchgroup=cppRawDelimiter start=+\%(u8\|[uLU]\)\=R"\z([[:alnum:]_{}[\]#<>%:;.?*\+\-/\^&|~!=,"']\{,16}\)(+ end=+)\z1"+ contains=@Spell
 endif
 
+" C++ 14 extensions
+if !exists("cpp_no_cpp14")
+  syn match cppNumber		display "\<0b[01]\+\(u\=l\{0,2}\|ll\=u\)\>"
+endif
+
 " The minimum and maximum operators in GNU C++
 syn match cppMinMax "[<>]?"
 
@@ -65,6 +70,7 @@ if version >= 508 || !exists("did_cpp_syntax_inits")
   HiLink cppConstant		Constant
   HiLink cppRawDelimiter	Delimiter
   HiLink cppRawString		String
+  HiLink cppNumber		Number
   delcommand HiLink
 endif
 


### PR DESCRIPTION
[ISO/IEC 14882:2014](http://www.iso.org/iso/catalogue_detail.htm?csnumber=64029) was issued at the beginning of this year.  So we should start to improve vim-cpp to work well with C++14 code, I think.

As a first work, I added `g:cpp_no_cpp14` variable check and a highlight for binary literal.

```cpp
int main()
{
    0b01010100010;
    0b01010100010ll;
    0b01010100010ul;

    return 0;
}
```