### PR TITLE
Fix auto and remove old binary literals

### DIFF
--- a/syntax/c.vim
+++ b/syntax/c.vim
@@ -182,11 +182,6 @@ syn match	cNumbersCom	display contained transparent "\<\d\|\.\d" contains=cNumbe
 syn match	cNumber		display contained "\d\+\(u\=l\{0,2}\|ll\=u\)\>"
 "hex number
 syn match	cNumber		display contained "0x\x\+\(u\=l\{0,2}\|ll\=u\)\>"
-if s:ft ==# 'cpp' && !exists("cpp_no_cpp14")
-  syn match	cNumber		display contained "\d\('\=\d\+\)*\(u\=l\{0,2}\|ll\=u\)\>"
-  syn match	cNumber		display contained "0x\x\('\=\x\+\)*\(u\=l\{0,2}\|ll\=u\)\>"
-  syn match	cNumber		display contained "0b[01]\('\=[01]\+\)*\(u\=l\{0,2}\|ll\=u\)\>"
-endif
 " Flag the first zero of an octal number as something special
 syn match	cOctal		display contained "0\o\+\(u\=l\{0,2}\|ll\=u\)\>" contains=cOctalZero
 syn match	cOctalZero	display contained "\<0"

--- a/syntax/cpp.vim
+++ b/syntax/cpp.vim
@@ -51,6 +51,15 @@ if !exists("cpp_no_cpp11")
   syn region cppRawString	matchgroup=cppRawStringDelimiter start=+\%(u8\|[uLU]\)\=R"\z([[:alnum:]_{}[\]#<>%:;.?*\+\-/\^&|~!=,"']\{,16}\)(+ end=+)\z1"+ contains=@Spell
 endif
 
+" C++ 14 extensions
+if !exists("cpp_no_cpp14")
+  syn case ignore
+  syn match cppNumber		display "\<0b[01]\('\=[01]\+\)*\(u\=l\{0,2}\|ll\=u\)\>"
+  syn match cppNumber		display "\<[1-9]\('\=\d\+\)*\(u\=l\{0,2}\|ll\=u\)\>"
+  syn match cppNumber		display "\<0x\x\('\=\x\+\)*\(u\=l\{0,2}\|ll\=u\)\>"
+  syn case match
+endif
+
 " The minimum and maximum operators in GNU C++
 syn match cppMinMax "[<>]?"
 
@@ -75,6 +84,7 @@ if version >= 508 || !exists("did_cpp_syntax_inits")
   HiLink cppConstant		Constant
   HiLink cppRawStringDelimiter	Delimiter
   HiLink cppRawString		String
+  HiLink cppNumber		Number
   delcommand HiLink
 endif
 

--- a/syntax/cpp.vim
+++ b/syntax/cpp.vim
@@ -51,11 +51,6 @@ if !exists("cpp_no_cpp11")
   syn region cppRawString	matchgroup=cppRawStringDelimiter start=+\%(u8\|[uLU]\)\=R"\z([[:alnum:]_{}[\]#<>%:;.?*\+\-/\^&|~!=,"']\{,16}\)(+ end=+)\z1"+ contains=@Spell
 endif
 
-" C++ 14 extensions
-if !exists("cpp_no_cpp14")
-  syn match cppNumber		display "\<0b[01]\+\(u\=l\{0,2}\|ll\=u\)\>"
-endif
-
 " The minimum and maximum operators in GNU C++
 syn match cppMinMax "[<>]?"
 
@@ -80,7 +75,6 @@ if version >= 508 || !exists("did_cpp_syntax_inits")
   HiLink cppConstant		Constant
   HiLink cppRawStringDelimiter	Delimiter
   HiLink cppRawString		String
-  HiLink cppNumber		Number
   delcommand HiLink
 endif
 

--- a/syntax/cpp.vim
+++ b/syntax/cpp.vim
@@ -37,8 +37,8 @@ syn keyword cppConstant		__cplusplus
 
 " C++ 11 extensions
 if !exists("cpp_no_cpp11")
-  syn keyword cppModifier	override final auto
-  syn keyword cppType		nullptr_t
+  syn keyword cppModifier	override final
+  syn keyword cppType		nullptr_t auto
   syn keyword cppExceptions	noexcept
   syn keyword cppStorageClass	constexpr decltype thread_local
   syn keyword cppConstant	nullptr


### PR DESCRIPTION
Fix terrible error with auto in previous PR, which has been cppModifier
Removed old binary literals syntax. Now all seems to be ok
```cpp
int d = 42;
int o = 052;
int x = 0x2a;
int X = 0X2A;
int b = 0b101010; // C++14
unsigned long long l1 = 18446744073709550592ull; // C++11
unsigned long long l2 = 18'446'744'073'709'550'592llu; // C++14
unsigned long long l3 = 1844'6744'0737'0955'0592uLL; // C++14
unsigned long long l4 = 184467'440737'0'95505'92LLU; // C++14
auto notbroken =  111'2'333;
```