### PR TITLE
Fix maintainer and remove date fields in header

### DIFF
--- a/syntax/cpp.vim
+++ b/syntax/cpp.vim
@@ -2,7 +2,6 @@
 " Language:	C++
 " Current Maintainer:	vim-jp (https://github.com/vim-jp/vim-cpp)
 " Previous Maintainer:	Ken Shan <ccshan@post.harvard.edu>
-" Last Change:	2016 Oct 28
 
 " quit when a syntax file was already loaded
 if exists("b:current_syntax")


### PR DESCRIPTION
Update the maintainer of c.vim to match cpp.vim and make Bram the
previous maintainer.

Remove the "Last Change" field from both files. Despite multiple updates
this year, both files had last changed marked as 2016. (Obviously the
effort to update these files is not worth doing it. I think it's better
to not be misleading.)

This change was motivated by finding these files inside vim-polyglot and
trying to find out where and when they're from. Better to provide less
information than incorrect information.