### PR TITLE
Add syntax folding to 'raw string' region

### DIFF
--- a/syntax/cpp.vim
+++ b/syntax/cpp.vim
@@ -44,7 +44,7 @@ if !exists("cpp_no_cpp11")
   syn keyword cppConstant	ATOMIC_WCHAR_T_LOCK_FREE ATOMIC_SHORT_LOCK_FREE
   syn keyword cppConstant	ATOMIC_INT_LOCK_FREE ATOMIC_LONG_LOCK_FREE
   syn keyword cppConstant	ATOMIC_LLONG_LOCK_FREE ATOMIC_POINTER_LOCK_FREE
-  syn region cppRawString	matchgroup=cppRawStringDelimiter start=+\%(u8\|[uLU]\)\=R"\z([[:alnum:]_{}[\]#<>%:;.?*\+\-/\^&|~!=,"']\{,16}\)(+ end=+)\z1"\(sv\|s\|_[_a-zA-Z][_a-zA-Z0-9]*\)\=+ contains=@Spell
+  syn region cppRawString	matchgroup=cppRawStringDelimiter start=+\%(u8\|[uLU]\)\=R"\z([[:alnum:]_{}[\]#<>%:;.?*\+\-/\^&|~!=,"']\{,16}\)(+ end=+)\z1"\(sv\|s\|_[_a-zA-Z][_a-zA-Z0-9]*\)\=+ contains=@Spell fold
   syn match cppCast		"\<\(const\|static\|dynamic\)_pointer_cast\s*<"me=e-1
   syn match cppCast		"\<\(const\|static\|dynamic\)_pointer_cast\s*$"
 endif


### PR DESCRIPTION
I have testcases that need JSON as input. Instead of making a file for each one, I inline the JSON as a raw string. It takes up too much screen real estate.
I do this on my machine, I think other people might appreciate it, too.