### PR TITLE
Add support for SWIG files

### DIFF
--- a/README
+++ b/README
@@ -1,0 +1,3 @@
+This is a mirror of http://www.vim.org/scripts/script.php?script_id=1615
+
+This is a syntax file for SWIG (Simplified Wrapper Interface Generator) description files.  The default syntax for .i files highlights comments in a reverse color scheme which is really horrible.  This syntax builds on vim's c++ syntax by adding highlighting for common swig directives and user defined directives.  For an alternative syntax, see  vimscript #1247 (which I found after writing this).  

--- a/ftdetect/swig.vim
+++ b/ftdetect/swig.vim
@@ -1,0 +1,1 @@
+autocmd BufNewFile,BufRead *.i,*.swg set filetype=swig

--- a/ftdetect/swig.vim
+++ b/ftdetect/swig.vim
@@ -1,1 +1,1 @@
-autocmd BufNewFile,BufRead *.i,*.swg set filetype=swig
+autocmd BufNewFile,BufRead *.i,*.swg,*.swig set filetype=swig

--- a/syntax/swig.vim
+++ b/syntax/swig.vim
@@ -1,0 +1,44 @@
+" Vim syntax file
+" Language:	SWIG
+" Maintainer:	Roman Stanchak (rstanchak@yahoo.com)
+" Last Change:	2006 July 25
+
+" For version 5.x: Clear all syntax items
+" For version 6.x: Quit when a syntax file was already loaded
+if version < 600
+  syntax clear
+elseif exists("b:current_syntax")
+  finish
+endif
+
+" Read the C++ syntax to start with
+if version < 600
+  so <sfile>:p:h/cpp.vim
+else
+  runtime! syntax/cpp.vim
+  unlet b:current_syntax
+endif
+
+" SWIG extentions
+syn keyword swigDirective %typemap %define %apply %fragment %include %enddef %extend %newobject %name 
+syn keyword swigDirective %rename %ignore %keyword %typemap %define %apply %fragment %include 
+syn keyword swigDirective %enddef %extend %newobject %name %rename %ignore %template %module %constant
+syn match swigDirective "%\({\|}\)"
+syn match swigUserDef "%[-_a-zA-Z0-9]\+"
+
+" Default highlighting
+if version >= 508 || !exists("did_swig_syntax_inits")
+  if version < 508
+    let did_cpp_syntax_inits = 1
+    command -nargs=+ HiLink hi link <args>
+  else
+    command -nargs=+ HiLink hi def link <args>
+  endif
+  HiLink swigDirective      Exception 
+  HiLink swigUserDef 		PreProc
+  delcommand HiLink
+endif
+
+let b:current_syntax = "swig"
+
+" vim: ts=8

--- a/syntax/swig.vim
+++ b/syntax/swig.vim
@@ -20,8 +20,8 @@ else
 endif
 
 " SWIG extentions
-syn keyword swigDirective %typemap %define %apply %fragment %include %enddef %extend %newobject %name 
-syn keyword swigDirective %rename %ignore %keyword %typemap %define %apply %fragment %include 
+syn keyword swigDirective %typemap %define %apply %fragment %include %enddef %extend %newobject %name
+syn keyword swigDirective %rename %ignore %keyword %typemap %define %apply %fragment %include
 syn keyword swigDirective %enddef %extend %newobject %name %rename %ignore %template %module %constant
 syn match swigDirective "%\({\|}\)"
 syn match swigUserDef "%[-_a-zA-Z0-9]\+"
@@ -34,7 +34,7 @@ if version >= 508 || !exists("did_swig_syntax_inits")
   else
     command -nargs=+ HiLink hi def link <args>
   endif
-  HiLink swigDirective      Exception 
+  HiLink swigDirective      Exception
   HiLink swigUserDef 		PreProc
   delcommand HiLink
 endif

--- a/syntax/swig.vim
+++ b/syntax/swig.vim
@@ -26,6 +26,13 @@ syn keyword swigDirective %enddef %extend %newobject %name %rename %ignore %temp
 syn match swigDirective "%\({\|}\)"
 syn match swigUserDef "%[-_a-zA-Z0-9]\+"
 
+" From Mr.Kissinger <mrkissinger@cmail.cn> (Mar 20th, 2005)
+" https://www.vim.org/account/profile.php?user_id=2977
+" syn match 	directive		"^\s*%\(\w\+\|{\|}\)"
+" syn match 	macro			"^\s*#\(define\|include\)"
+" syn match 	cKeyword		"\(int\|char\|void\|unsigned\|struct\)"
+" syn region	comment			start="//" skip="\\$" end="$"
+
 " Default highlighting
 if version >= 508 || !exists("did_swig_syntax_inits")
   if version < 508
@@ -38,6 +45,13 @@ if version >= 508 || !exists("did_swig_syntax_inits")
   HiLink swigUserDef 		PreProc
   delcommand HiLink
 endif
+
+" From Mr.Kissinger <mrkissinger@cmail.cn> (Mar 20th, 2005)
+" hi directive	gui=bold guifg='Red'
+" " hi macro		gui=bold guifg='Magenta'
+" hi cKeyword		gui=bold guifg='DarkGreen'
+" hi comment		gui=bold guifg='Blue'
+" let b:current_syntax = "c"
 
 let b:current_syntax = "swig"
 

--- a/syntax/swig.vim
+++ b/syntax/swig.vim
@@ -1,23 +1,16 @@
 " Vim syntax file
 " Language:	SWIG
-" Maintainer:	Roman Stanchak (rstanchak@yahoo.com)
-" Last Change:	2006 July 25
+" Current Maintainer:	vim-jp (https://github.com/vim-jp/vim-cpp)
+" Previous Maintainer:	Roman Stanchak (rstanchak@yahoo.com)
+" Last Change:	2023 April 27
 
-" For version 5.x: Clear all syntax items
-" For version 6.x: Quit when a syntax file was already loaded
-if version < 600
-  syntax clear
-elseif exists("b:current_syntax")
-  finish
+if exists("b:current_syntax")
+	finish
 endif
 
 " Read the C++ syntax to start with
-if version < 600
-  so <sfile>:p:h/cpp.vim
-else
-  runtime! syntax/cpp.vim
-  unlet b:current_syntax
-endif
+runtime! syntax/cpp.vim
+unlet b:current_syntax
 
 " SWIG extentions
 syn keyword swigDirective %typemap %define %apply %fragment %include %enddef %extend %newobject %name
@@ -26,32 +19,11 @@ syn keyword swigDirective %enddef %extend %newobject %name %rename %ignore %temp
 syn match swigDirective "%\({\|}\)"
 syn match swigUserDef "%[-_a-zA-Z0-9]\+"
 
-" From Mr.Kissinger <mrkissinger@cmail.cn> (Mar 20th, 2005)
-" https://www.vim.org/account/profile.php?user_id=2977
-" syn match 	directive		"^\s*%\(\w\+\|{\|}\)"
-" syn match 	macro			"^\s*#\(define\|include\)"
-" syn match 	cKeyword		"\(int\|char\|void\|unsigned\|struct\)"
-" syn region	comment			start="//" skip="\\$" end="$"
-
 " Default highlighting
-if version >= 508 || !exists("did_swig_syntax_inits")
-  if version < 508
-    let did_cpp_syntax_inits = 1
-    command -nargs=+ HiLink hi link <args>
-  else
-    command -nargs=+ HiLink hi def link <args>
-  endif
-  HiLink swigDirective      Exception
-  HiLink swigUserDef 		PreProc
-  delcommand HiLink
-endif
-
-" From Mr.Kissinger <mrkissinger@cmail.cn> (Mar 20th, 2005)
-" hi directive	gui=bold guifg='Red'
-" " hi macro		gui=bold guifg='Magenta'
-" hi cKeyword		gui=bold guifg='DarkGreen'
-" hi comment		gui=bold guifg='Blue'
-" let b:current_syntax = "c"
+command -nargs=+ HiLink hi def link <args>
+HiLink swigDirective	Exception
+HiLink swigUserDef 		PreProc
+delcommand HiLink
 
 let b:current_syntax = "swig"
 


### PR DESCRIPTION
**Is your feature request about something that is currently impossible or hard to do? Please describe the problem.**

It is difficult to work with SWIG files (https://swig.org/ “SWIG is a software development tool that connects programs written in C and C++ with a variety of high-level programming languages. SWIG is used with different types of target languages including common scripting languages such as Javascript, Perl, PHP, Python, Tcl, Ruby, and others.”). SWIG uses `*.i` files, which are C/C++ files with some included macros.

**Describe the solution you'd like**
There are two plugins for dealing with SWIG files:

* https://www.vim.org/scripts/script.php?script_id=1615 by @rstanchak 
* https://www.vim.org/scripts/script.php?script_id=1247 by Mr.Kissinger

I have tried to merge capabilities of both scripts, but in the end the second script doesn’t bring much to the table, so in the end my repository is just the first script with some clean-up.